### PR TITLE
Change string representation of columns containing time for getItem()

### DIFF
--- a/impl/procedure_wrappers.lua
+++ b/impl/procedure_wrappers.lua
@@ -33,11 +33,19 @@ local function requireNonNil (x)
   return x 
 end
 
+local function filter_time_to_string (t)
+  if (type(t) == "table") and (t.year ~= nil) and (t.month ~= nil) and (t.day ~= nil) and (t.week_day ~= nil) and (t.hour ~= nil) and (t.min ~= nil) and (t.sec ~= nil) and (t.ms ~= nil) and (t.mcs ~= nil) then
+    return string.format("quik_time(year=%s,month=%s,day=%s,week_day=%s,hour=%s,min=%s,sec=%s,ms=%s,mcs=%s)", t.year, t.month, t.day, t.week_day, t.hour, t.min, t.sec, t.ms, t.mcs)
+  else
+    return t
+  end
+end
+
 local function to_string_string_table (t)
   
   local result = {}
   for k, v in pairs(t) do
-    result[utils.Cp1251ToUtf8(tostring(k))] = utils.Cp1251ToUtf8(tostring(v))
+    result[utils.Cp1251ToUtf8(tostring(k))] = utils.Cp1251ToUtf8(tostring(filter_time_to_string(v)))
   end
   
   return result


### PR DESCRIPTION
Values containing time were converted to string by getItem with tostring() function,
that converts lua table to string with format "table: <id>" where <id> is some meaningless
hexadecimal number. With this commit values containing fields "year", "month", "day",
"week_day", "hour", "min", "sec", "ms" and "mcs" will be converted to string with
format "quik_time(year=<year>,month=<month>,day=<day>,week_day=<week_day>,hour=<hour>,min=<min>,sec=<sec>,ms=<ms>,mcs=<mcs>)"
where <...> placeholders refers to corresponding fields.

Fix #35